### PR TITLE
Add osenv package for getting env variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.idea/
+.vscode/
+vendor/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,3 @@
+# Makefile
+test:
+	@go test -cover ./...

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,8 @@
+module github/wherevn/kit
+
+go 1.14
+
+require (
+	github.com/joho/godotenv v1.3.0
+	github.com/stretchr/testify v1.5.1
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,12 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/joho/godotenv v1.3.0 h1:Zjp+RcGpHhGlrMbJzXTrZZPrWj+1vfm90La1wgB6Bhc=
+github.com/joho/godotenv v1.3.0/go.mod h1:7hK45KPybAkOC6peb+G5yklZfMxEjkZhHbwpqxOKXbg=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
+github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
+gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/osenv/osenv.go
+++ b/osenv/osenv.go
@@ -1,0 +1,58 @@
+package osenv
+
+import (
+	"os"
+	"strconv"
+
+	"github.com/joho/godotenv"
+)
+
+// LoadFile env configuration from file.
+func LoadFile(fileNames ...string) error {
+	err := godotenv.Load(fileNames...)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func GetInt(key string, defaultValues ...int) int {
+	var val int
+	if len(defaultValues) > 0 {
+		val = defaultValues[0]
+	}
+	if envVal, isExist := getEnv(key); isExist {
+		if v, err := strconv.Atoi(envVal); err == nil {
+			val = v
+		}
+	}
+	return val
+}
+
+func GetString(key string, defaultValues ...string) string {
+	var val string
+	if len(defaultValues) > 0 {
+		val = defaultValues[0]
+	}
+	if envVal, isExist := getEnv(key); isExist {
+		val = envVal
+	}
+	return val
+}
+
+func GetBool(key string, defaultValues ...bool) bool {
+	var val bool
+	if len(defaultValues) > 0 {
+		val = defaultValues[0]
+	}
+	if envVal, isExist := getEnv(key); isExist {
+		if v, err := strconv.ParseBool(envVal); err == nil {
+			val = v
+		}
+	}
+	return val
+}
+
+func getEnv(key string) (string, bool) {
+	return os.LookupEnv(key)
+}

--- a/osenv/osenv_test.go
+++ b/osenv/osenv_test.go
@@ -1,0 +1,77 @@
+package osenv
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	TestDataFileTestConf = "testdata/test_conf.env"
+)
+
+func TestLoadFile(t *testing.T) {
+	t.Run("OK", func(t *testing.T) {
+		err := LoadFile(TestDataFileTestConf)
+		assert.NoError(t, err)
+		assert.Equal(t, "CONF_1", os.Getenv("CONF_1"))
+		assert.Equal(t, "CONF_2", os.Getenv("CONF_2"))
+	})
+
+	t.Run("FAIL_TO_LOAD_CONF_FILE", func(t *testing.T) {
+		err := LoadFile("testdata/file_doesnt_exist.env")
+		assert.Error(t, err)
+	})
+}
+
+func TestGetInt(t *testing.T) {
+	const testIntEnvKey = "TEST_INT_ENV"
+
+	err := os.Setenv(testIntEnvKey, "123")
+	assert.NoError(t, err)
+
+	t.Run("OK", func(t *testing.T) {
+		confVal := GetInt(testIntEnvKey)
+		assert.Equal(t, 123, confVal)
+	})
+
+	t.Run("GET_DEFAULT_CONF", func(t *testing.T) {
+		confVal := GetInt("DOESNT_EXIST_CONF", 333)
+		assert.Equal(t, 333, confVal)
+	})
+}
+
+func TestGetString(t *testing.T) {
+	const testStringEnvKey = "TEST_STRING_ENV"
+
+	err := os.Setenv(testStringEnvKey, "string")
+	assert.NoError(t, err)
+
+	t.Run("OK", func(t *testing.T) {
+		confVal := GetString(testStringEnvKey)
+		assert.Equal(t, "string", confVal)
+	})
+
+	t.Run("GET_DEFAULT_CONF", func(t *testing.T) {
+		confVal := GetString("DOESNT_EXIST_CONF", "string")
+		assert.Equal(t, "string", confVal)
+	})
+}
+
+func TestGetBool(t *testing.T) {
+	const testBoolEnvKey = "TEST_BOOL_ENV"
+
+	err := os.Setenv(testBoolEnvKey, "true")
+	assert.NoError(t, err)
+
+	t.Run("OK", func(t *testing.T) {
+		confVal := GetBool(testBoolEnvKey)
+		assert.Equal(t, true, confVal)
+	})
+
+	t.Run("GET_DEFAULT_CONF", func(t *testing.T) {
+		confVal := GetBool("DOESNT_EXIST_CONF", true)
+		assert.Equal(t, true, confVal)
+	})
+}

--- a/osenv/testdata/test_conf.env
+++ b/osenv/testdata/test_conf.env
@@ -1,0 +1,2 @@
+CONF_1: "CONF_1"
+CONF_2 = "CONF_2"


### PR DESCRIPTION
## Proposed Changes:

- Load env variables from *.env files
- Get env variables as a String
- Get env variables as a Bool
- Get env variables as a Integer

## Checklist:

- [x] Lint and unit tests pass locally with my changes
